### PR TITLE
Refactor CMD to reflect cobra defaults

### DIFF
--- a/cmd/convert.go
+++ b/cmd/convert.go
@@ -1,33 +1,31 @@
 package cmd
 
 import (
-	"github.com/pkg/errors"
-	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
-	"github.com/surajssd/opencomposition/pkg"
+	"fmt"
+	"os"
 
-	log "github.com/Sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/surajssd/opencomposition/pkg"
 )
 
-func NewConvertCommand(v *viper.Viper) *cobra.Command {
-	cmd := &cobra.Command{
-		Use: "convert",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return RunConvert(v, cmd)
-		},
-	}
-	cmd.PersistentFlags().StringSliceP("files", "f", []string{}, "Specify opencompose files")
-	v.BindPFlag("files", cmd.PersistentFlags().Lookup("files"))
-	cmd.PersistentFlags().BoolP("verbose", "v", false, "Specify if you want to see debug mode output")
-	v.BindPFlag("verbose", cmd.PersistentFlags().Lookup("verbose"))
+// Variables
+var (
+	ConvertFiles []string
+)
 
-	return cmd
+// convertCmd represents the convert command
+var convertCmd = &cobra.Command{
+	Use:   "convert",
+	Short: "Convert an application to Kubernetes resources",
+	Run: func(cmd *cobra.Command, args []string) {
+		if err := pkg.Convert(ConvertFiles); err != nil {
+			fmt.Println(err)
+			os.Exit(-1)
+		}
+	},
 }
 
-func RunConvert(v *viper.Viper, cmd *cobra.Command) error {
-	if v.GetBool("verbose") {
-		log.SetLevel(log.DebugLevel)
-	}
-
-	return errors.Wrap(pkg.Convert(v, cmd), "failed conversion")
+func init() {
+	convertCmd.Flags().StringArrayVarP(&ConvertFiles, "files", "f", []string{}, "Specify files")
+	RootCmd.AddCommand(convertCmd)
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,31 +1,40 @@
 package cmd
 
 import (
-	"errors"
-	"strings"
+	"fmt"
+	"os"
 
+	log "github.com/Sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
-func NewRootCommand() *cobra.Command {
-	v := viper.New()
-	v.SetEnvPrefix("opencomposition")
-	v.AutomaticEnv()
-	replacer := strings.NewReplacer("-", "_")
-	v.SetEnvKeyReplacer(replacer)
+// Global variables
+var (
+	GlobalVerbose bool
+)
 
-	var rootCmd = &cobra.Command{
-		Use: "opencomposition",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			//if err := cmd.Help(); err != nil {
-			//	return err
-			//}
-			return errors.New("Use 'opencomposition convert'")
-		},
+// RootCmd represents the base command when called without any subcommands
+var RootCmd = &cobra.Command{
+	Use:   "opencomposition",
+	Short: "Compose Kubernetes applications using Kubernetes constructs",
+	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+
+		// Add extra logging when verbosity is passed
+		if GlobalVerbose {
+			log.SetLevel(log.DebugLevel)
+		}
+
+	},
+}
+
+func Execute() {
+	if err := RootCmd.Execute(); err != nil {
+		fmt.Println(err)
+		os.Exit(-1)
 	}
+}
 
-	rootCmd.AddCommand(NewConvertCommand(v))
-
-	return rootCmd
+// Initialize all flags
+func init() {
+	RootCmd.PersistentFlags().BoolVarP(&GlobalVerbose, "verbose", "v", false, "verbose output")
 }

--- a/main.go
+++ b/main.go
@@ -1,15 +1,7 @@
 package main
 
-import (
-	"os"
-
-	"github.com/surajssd/opencomposition/cmd"
-)
+import "github.com/surajssd/opencomposition/cmd"
 
 func main() {
-	cmd := cmd.NewRootCommand()
-	if err := cmd.Execute(); err != nil {
-		//log.Println(err)
-		os.Exit(-1)
-	}
+	cmd.Execute()
 }

--- a/pkg/opencomposition.go
+++ b/pkg/opencomposition.go
@@ -4,13 +4,10 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"strings"
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/ghodss/yaml"
 	"github.com/pkg/errors"
-	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 	"k8s.io/client-go/pkg/api"
 	"k8s.io/client-go/pkg/api/resource"
 	"k8s.io/client-go/pkg/runtime"
@@ -57,9 +54,9 @@ func ReadFile(f string) ([]byte, error) {
 	return data, nil
 }
 
-func Convert(v *viper.Viper, cmd *cobra.Command) error {
+func Convert(files []string) error {
 
-	for _, file := range strings.Split(v.GetStringSlice("files")[0], ",") {
+	for _, file := range files {
 		d, err := ReadFile(file)
 		if err != nil {
 			return errors.New(err.Error())


### PR DESCRIPTION
Refactors the cmd / cli folder to use the standard cobra templates (via
`cobra init` and `cobra new`. Cleans this up so it's much cleaner.

Also changes `pkg/opencomposition.go` to avoid using cobra / viper in
it's code (completely separate it from everywhere else).