### PR TITLE
refactor code

### DIFF
--- a/cmd/convert.go
+++ b/cmd/convert.go
@@ -5,7 +5,7 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
-	"github.com/surajssd/opencomposition/pkg"
+	pkgcmd "github.com/surajssd/opencomposition/pkg/cmd"
 )
 
 // Variables
@@ -18,7 +18,7 @@ var convertCmd = &cobra.Command{
 	Use:   "convert",
 	Short: "Convert an application to Kubernetes resources",
 	Run: func(cmd *cobra.Command, args []string) {
-		if err := pkg.Convert(ConvertFiles); err != nil {
+		if err := pkgcmd.Convert(ConvertFiles); err != nil {
 			fmt.Println(err)
 			os.Exit(-1)
 		}

--- a/pkg/cmd/convert.go
+++ b/pkg/cmd/convert.go
@@ -1,0 +1,59 @@
+package cmd
+
+import (
+	"io/ioutil"
+
+	"fmt"
+	"os"
+
+	"github.com/ghodss/yaml"
+	"github.com/pkg/errors"
+	"github.com/surajssd/opencomposition/pkg/encoding"
+	"github.com/surajssd/opencomposition/pkg/transform/kubernetes"
+	"k8s.io/client-go/pkg/runtime"
+)
+
+func Convert(files []string) error {
+
+	for _, file := range files {
+
+		data, err := ioutil.ReadFile(file)
+		if err != nil {
+			return errors.Wrap(err, "file reading failed")
+		}
+
+		app, err := encoding.Decode(data)
+		if err != nil {
+			return errors.Wrap(err, "unable to unmarshal data")
+		}
+
+		ros, err := kubernetes.Transform(app)
+		if err != nil {
+			return errors.Wrap(err, "unable to convert data")
+		}
+
+		for _, runtimeObject := range ros {
+
+			data, err := yaml.Marshal(runtimeObject)
+			if err != nil {
+				return errors.Wrap(err, "failed to marshal object")
+			}
+
+			writeObject := func(o runtime.Object, data []byte) error {
+				_, err := fmt.Fprintln(os.Stdout, "---")
+				if err != nil {
+					return errors.Wrap(err, "could not print to STDOUT")
+				}
+
+				_, err = os.Stdout.Write(data)
+				return errors.Wrap(err, "could not write to STDOUT")
+			}
+
+			err = writeObject(runtimeObject, data)
+			if err != nil {
+				return errors.Wrap(err, "failed to write object")
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/encoding/encoding.go
+++ b/pkg/encoding/encoding.go
@@ -1,0 +1,22 @@
+package encoding
+
+import (
+	"github.com/ghodss/yaml"
+	"github.com/pkg/errors"
+
+	log "github.com/Sirupsen/logrus"
+
+	"github.com/surajssd/opencomposition/pkg/spec"
+)
+
+func Decode(data []byte) (*spec.App, error) {
+
+	var app spec.App
+	err := yaml.Unmarshal(data, &app)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not unmarshal into internal struct")
+	}
+	log.Debugf("object unmrashalled: %#v\n", app)
+	return &app, nil
+
+}

--- a/pkg/spec/spec.go
+++ b/pkg/spec/spec.go
@@ -1,0 +1,28 @@
+package spec
+
+import (
+	api_v1 "k8s.io/client-go/pkg/api/v1"
+	ext_v1beta1 "k8s.io/client-go/pkg/apis/extensions/v1beta1"
+)
+
+type Volume struct {
+	api_v1.Volume `yaml:",inline"`
+	Size          string   `yaml:"size"`
+	AccessModes   []string `yaml:"accessModes"`
+}
+
+type Service struct {
+	Name                    string `yaml:"name,omitempty"`
+	api_v1.ServiceSpec      `yaml:",inline"`
+	ext_v1beta1.IngressSpec `yaml:",inline"`
+}
+
+type App struct {
+	Name              string            `yaml:"name"`
+	Replicas          *int32            `yaml:"replicas,omitempty"`
+	Labels            map[string]string `yaml:"labels,omitempty"`
+	PersistentVolumes []Volume          `yaml:"persistentVolumes,omitempty"`
+	ConfigData        map[string]string `yaml:"configData,omitempty"`
+	Services          []Service         `yaml:"services,omitempty"`
+	api_v1.PodSpec    `yaml:",inline"`
+}


### PR DESCRIPTION
This refactors the pkg/ directory to the following -

├── cmd
│   └── convert.go
├── encoding
│   └── encoding.go
├── spec
│   └── spec.go
└── transform
    └── kubernetes
        └── kubernetes.go

We can refactor more later on, but I think this provides a boiler
plate for a structure.